### PR TITLE
[CSL-1703] Fix space leak in readback buffer

### DIFF
--- a/src/System/Wlog/Handler/Simple.hs
+++ b/src/System/Wlog/Handler/Simple.hs
@@ -69,7 +69,9 @@ streamHandler h sev = do
     mq <- newMVar $ MQ.newMemoryQueue $ 2 * 1024 * 1024 -- 2 MB
     let mywritefunc hdl msg = withMVar lock $ const $ do
             writeToHandle hdl msg
-            modifyMVar_ mq $ pure . pushFront msg
+            -- Important to force the queue here, else a massive closure will
+            -- be retained until the queue is actually used.
+            modifyMVar_ mq $ \mq' -> pure $! pushFront msg mq'
             hFlush hdl
     return
         GenericHandler

--- a/src/System/Wlog/Handler/Simple.hs
+++ b/src/System/Wlog/Handler/Simple.hs
@@ -55,7 +55,7 @@ instance Typeable a => LogHandler (GenericHandler a) where
     getLevel sh = severity sh
     setFormatter sh f = sh{formatter = f}
     getFormatter sh = formatter sh
-    readBack sh i = withMVar (readBackBuffer sh) $ pure . take i . MQ.toList
+    readBack sh i = withMVar (readBackBuffer sh) $ \mq -> pure $! take i (MQ.toList mq)
     emit sh (_,msg) _ = (writeFunc sh) (privData sh) msg
     close sh = (closeFunc sh) (privData sh)
 


### PR DESCRIPTION
```
{-# LANGUAGE OverloadedStrings #-}

import System.Wlog

main = do
  parseLoggerConfig "log-config.yaml" >>= setupLogging
  usingLoggerName "node" logForever

logForever :: LoggerNameBox IO ()
logForever = do
    logDebug "debug"
    logForever
```

```
# log-config.yaml
severity: Info
node:
    severity: Debug
```

This program would leak memory unless the read back buffer memory queue is regularly forced by some other means. With this patch it won't leak past the bounds given (`2 * 1024 * 1024` currently). Should mention as well that the limit is actually on the number of characters in the memory queue, rather than the number of bytes, so docs should be updated.