### PR TITLE
[CSL-1739] Add ability to specify time format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+1.2.4
+=====
+
+* Add ability to specify time format for logs.
+* Some space leaks elimination:
+  + The `MemoryQueue` has been partially reworked to get rid of the "inline" State manipulation;
+  + Strings have been dropped almost everywhere in favour of `Text`;
+  + A `LogFormatter` has been reworked to yield a `IO Builder`;
+  + `replaceVarM` has been reworked to be pure _and_ to work with builders rather than plain Text/Strings;
+  + The pure logger has been reworked to use strict's `StateT` instead of WriterT;
+  + The pure logger have been polished to drop instances which required the `UndecidableInstances` pragma;
+  + The `Sized` instance for `Text` has been reworked and multiplied by a constant factor of 16 (see below).
+
 1.2.3
 =====
 

--- a/log-warper.cabal
+++ b/log-warper.cabal
@@ -1,5 +1,5 @@
 name:                log-warper
-version:             1.2.3
+version:             1.2.4
 synopsis:            Flexible, configurable, monadic and pretty logging
 homepage:            https://github.com/serokell/log-warper
 license:             MIT

--- a/log-warper.cabal
+++ b/log-warper.cabal
@@ -1,5 +1,5 @@
 name:                log-warper
-version:             1.2.4
+version:             1.3.0
 synopsis:            Flexible, configurable, monadic and pretty logging
 homepage:            https://github.com/serokell/log-warper
 license:             MIT
@@ -46,6 +46,7 @@ library
                      , exceptions           >= 0.8.3
                      , extra                >= 1.4.10
                      , filepath             >= 1.4.1
+                     , fmt                  >= 0.5.0.0
                      , formatting           >= 6.2.2
                      , hashable             >= 1.2.4.0
                      , lens                 >= 4.14

--- a/src/System/Wlog/Formatter.hs
+++ b/src/System/Wlog/Formatter.hs
@@ -18,6 +18,7 @@ module System.Wlog.Formatter
        ( stdoutFormatter
        , stderrFormatter
        , stdoutFormatterTimeRounded
+       , centiUtcTimeF
        , getRoundedTime
 
        -- * Taken from @hslogger@.
@@ -28,6 +29,8 @@ module System.Wlog.Formatter
        , varFormatter
        ) where
 
+import           Universum
+
 import           Control.Concurrent     (myThreadId)
 import           Data.Monoid            (mconcat)
 import qualified Data.Text              as T
@@ -35,7 +38,9 @@ import           Data.Text.Lazy.Builder as B
 import           Data.Time              (formatTime, getCurrentTime, getZonedTime)
 import           Data.Time.Clock        (UTCTime (..))
 import           Data.Time.Format       (FormatTime)
-import           Universum
+import           Fmt                    (fmt, padRightF, (+|), (|+), (|++|))
+import           Fmt.Time               (dateDashF, hmsF, subsecondF, tzNameF)
+
 #ifndef mingw32_HOST_OS
 import           System.Posix.Process   (getProcessID)
 #endif
@@ -154,11 +159,16 @@ simpleLogFormatter format h logRecord loggername =
 -- Log-warper functionality
 ----------------------------------------------------------------------------
 
-timeFmt :: Text
-timeFmt = "[$time] "
-
-timeFmtStdout :: Bool -> Text
-timeFmtStdout = bool mempty timeFmt
+-- | Formats UTC time in next format: "%Y-%m-%d %H:%M:%S%Q %Z"
+-- but %Q part show only in centiseconds (always 2 digits).
+centiUtcTimeF :: UTCTime -> Text
+centiUtcTimeF t =
+    dateDashF    t |+ " "
+ +| hmsF         t |++|
+    centiSecondF t |+ " "
+ +| tzNameF      t |+ ""
+  where
+    centiSecondF = padRightF 3 '0' . T.take 3 . fmt . subsecondF
 
 getRoundedTime :: Int -> IO UTCTime
 getRoundedTime roundN = do
@@ -169,30 +179,46 @@ getRoundedTime roundN = do
     roundBy :: (Num a, Integral a) => a -> a
     roundBy x = let y = x `div` fromIntegral roundN in y * fromIntegral roundN
 
-stdoutFmt :: Severity -> Bool -> Bool -> Text
-stdoutFmt pr isShowTime isShowTid = mconcat $!
-    [colorizer pr $ "[$loggername:$prio" <> tid <> "] ", timeFmtStdout isShowTime, "$msg"]
+stdoutFormatter :: (UTCTime -> Text) -> Bool -> Bool -> LogFormatter a
+stdoutFormatter timeF isShowTime isShowTid handle record message = do
+    time <- getCurrentTime
+    createLogFormatter isShowTime isShowTid timeF time handle record message
+
+stderrFormatter :: (UTCTime -> Text) -> Bool -> LogFormatter a
+stderrFormatter timeF isShowTid handle (LR _ x) message = do
+    time <- getCurrentTime
+    createLogFormatter True isShowTid timeF time handle (LR Error x) message
+
+stdoutFormatterTimeRounded :: (UTCTime -> Text) -> Int -> LogFormatter a
+stdoutFormatterTimeRounded timeF roundN handle record message = do
+    time <- getRoundedTime roundN
+    createLogFormatter True True timeF time handle record message
+
+createLogFormatter
+    :: Bool
+    -> Bool
+    -> (UTCTime -> Text)
+    -> UTCTime
+    -> LogFormatter a
+createLogFormatter
+    isShowTime
+    isShowTid
+    timeF
+    time
+    handle
+    record@(LR priority _)
+  =
+    simpleLogFormatter format handle record
   where
-    tid = if isShowTid then ":$tid" else mempty
+    format = mconcat $!
+        [ colorizer priority $ "[$loggername:$prio" <> tidShower <> "] "
+        , timeShower
+        , "$msg"
+        ]
 
-stdoutFormatter :: Text -> Bool -> Bool -> LogFormatter a
-stdoutFormatter timeFormat isShowTime isShowTid handle r@(LR pr _) =
-    tfLogFormatter timeFormat (stdoutFmt pr isShowTime isShowTid) handle r
-
-stderrFormatter :: Text -> Bool -> LogFormatter a
-stderrFormatter timeFormat isShowTid handle r@(LR _ _) =
-    tfLogFormatter timeFormat (stdoutFmt Error True isShowTid) handle r
-
-stdoutFormatterTimeRounded :: Text -> Int -> LogFormatter a
-stdoutFormatterTimeRounded timeFormat roundN a r@(LR pr _) s = do
-    t <- getRoundedTime roundN
-    simpleLogFormatter (fmt t) a r s
-  where
-    fmt time = mconcat $!
-        [ colorizer pr "[$loggername:$prio:$tid]"
-        , " ["
-        , T.pack $ formatTime defaultTimeLocale (T.unpack timeFormat) time
-        , "] $msg"]
+    timeShower, tidShower :: Text
+    timeShower = if isShowTime then "[" <> timeF time <> "] " else mempty
+    tidShower  = if isShowTid  then ":$tid"                   else mempty
 
 {- TODO: not used anymore, but probably should
 formatLogMessage :: LoggerName -> Severity -> UTCTime -> Text -> Text

--- a/src/System/Wlog/Launcher.hs
+++ b/src/System/Wlog/Launcher.hs
@@ -36,12 +36,14 @@ import           Control.Error.Util         ((?:))
 import           Control.Exception          (throwIO)
 import qualified Data.HashMap.Strict        as HM hiding (HashMap)
 import qualified Data.Text                  as T
+import           Data.Time                  (UTCTime)
 import           Data.Yaml                  (decodeFileEither)
 import           System.Directory           (createDirectoryIfMissing)
 import           System.FilePath            ((</>))
 import           Universum
 
-import           System.Wlog.Formatter      (stdoutFormatter, stdoutFormatterTimeRounded)
+import           System.Wlog.Formatter      (centiUtcTimeF, stdoutFormatter,
+                                             stdoutFormatterTimeRounded)
 import           System.Wlog.Handler        (LogHandler (setFormatter))
 import           System.Wlog.Handler.Roller (rotationFileHandler)
 import           System.Wlog.Handler.Simple (fileHandler)
@@ -58,12 +60,12 @@ data HandlerFabric
 -- | This function traverses 'LoggerConfig' initializing all subloggers
 -- with 'Severity' and redirecting output in file handlers.
 -- See 'LoggerConfig' for more details.
-setupLogging :: MonadIO m => LoggerConfig -> m ()
-setupLogging LoggerConfig{..} = do
+setupLogging :: MonadIO m => Maybe (UTCTime -> Text) -> LoggerConfig -> m ()
+setupLogging mTimeFunction LoggerConfig{..} = do
     liftIO $ createDirectoryIfMissing True handlerPrefix
 
     when consoleOutput $
-        initTerminalLogging timeFormat
+        initTerminalLogging timeF
                             isShowTime
                             isShowTid
                             _lcTermSeverity
@@ -73,7 +75,7 @@ setupLogging LoggerConfig{..} = do
   where
     handlerPrefix = _lcFilePrefix ?: "."
     logMapper     = appEndo _lcMapper
-    timeFormat    = fromMaybe "%Y-%m-%d %H:%M:%S%Q %Z" _lcTimeFormat
+    timeF         = fromMaybe centiUtcTimeF mTimeFunction
     isShowTime    = getAny _lcShowTime
     isShowTid     = getAny _lcShowTid
     consoleOutput = getAny _lcConsoleOutput
@@ -95,8 +97,8 @@ setupLogging LoggerConfig{..} = do
             case handlerFabric of
                 HandlerFabric fabric -> do
                     let handlerCreator = fabric handlerPath fileSeverity
-                    let defFmt = (`setFormatter` stdoutFormatter timeFormat isShowTime isShowTid)
-                    let roundFmt r = (`setFormatter` stdoutFormatterTimeRounded timeFormat r)
+                    let defFmt = (`setFormatter` stdoutFormatter timeF isShowTime isShowTid)
+                    let roundFmt r = (`setFormatter` stdoutFormatterTimeRounded timeF r)
                     let fmt = maybe defFmt roundFmt _hwRounding
                     thisLoggerHandler <- fmt <$> handlerCreator
                     updateGlobalLogger (loggerName parent) $ addHandler thisLoggerHandler
@@ -116,7 +118,7 @@ buildAndSetupYamlLogging :: MonadIO m => LoggerConfig -> FilePath -> m ()
 buildAndSetupYamlLogging configBuilder loggerConfigPath = do
     cfg@LoggerConfig{..} <- parseLoggerConfig loggerConfigPath
     let builtConfig       = cfg <> configBuilder
-    setupLogging builtConfig
+    setupLogging Nothing builtConfig
 
 -- | Initialize logger hierarchy from configuration file.
 -- See this module description.

--- a/src/System/Wlog/LoggerConfig.hs
+++ b/src/System/Wlog/LoggerConfig.hs
@@ -38,7 +38,6 @@ module System.Wlog.LoggerConfig
        , lcMapper
        , lcRotation
        , lcShowTime
-       , lcTimeFormat
        , lcShowTid
        , lcTermSeverity
        , lcTree
@@ -48,7 +47,6 @@ module System.Wlog.LoggerConfig
        , consoleOutB
        , mapperB
        , maybePrefixB
-       , maybeTimeFormatB
        , prefixB
        , productionB
        , showTidB
@@ -199,12 +197,6 @@ data LoggerConfig = LoggerConfig
       -- Note that error messages always have timestamp.
     , _lcShowTime      :: Any
 
-      -- | Time format for messages. If not specified then next
-      -- default will be used:
-      -- >>> timeF "%Y-%m-%d %H:%M:%S%Q %Z" t
-      -- "2017-10-06 17:55:20.781549 MSK"
-    , _lcTimeFormat    :: Maybe Text
-
       -- | Show 'ThreadId' for current logging thread.
     , _lcShowTid       :: Any
 
@@ -229,7 +221,6 @@ instance Monoid LoggerConfig where
         { _lcRotation      = Nothing
         , _lcTermSeverity  = Nothing
         , _lcShowTime      = mempty
-        , _lcTimeFormat    = Nothing
         , _lcShowTid       = mempty
         , _lcConsoleOutput = mempty
         , _lcMapper        = mempty
@@ -241,7 +232,6 @@ instance Monoid LoggerConfig where
         { _lcRotation      = orCombiner  _lcRotation
         , _lcTermSeverity  = orCombiner  _lcTermSeverity
         , _lcShowTime      = andCombiner _lcShowTime
-        , _lcTimeFormat    = orCombiner  _lcTimeFormat
         , _lcShowTid       = andCombiner _lcShowTid
         , _lcConsoleOutput = andCombiner _lcConsoleOutput
         , _lcMapper        = andCombiner _lcMapper
@@ -262,7 +252,6 @@ instance FromJSON LoggerConfig where
         _lcRotation      <-         o .:? "rotation"
         _lcTermSeverity  <-         o .:? "termSeverity"
         _lcShowTime      <- Any <$> o .:? "showTime"    .!= False
-        _lcTimeFormat    <-         o .:? "timeFormat"
         _lcShowTid       <- Any <$> o .:? "showTid"     .!= False
         _lcConsoleOutput <- Any <$> o .:? "printOutput" .!= False
         _lcFilePrefix    <-         o .:? "filePrefix"
@@ -277,7 +266,6 @@ instance ToJSON LoggerConfig where
             [ "rotation"     .= _lcRotation
             , "termSeverity" .= _lcTermSeverity
             , "showTime"     .= getAny _lcShowTime
-            , "timeFormat"   .= _lcTimeFormat
             , "showTid"      .= getAny _lcShowTid
             , "printOutput"  .= getAny _lcConsoleOutput
             , "filePrefix"   .= _lcFilePrefix
@@ -293,10 +281,6 @@ showTimeB = mempty { _lcShowTime = Any True }
 -- | Setup 'lcShowTid' to 'True' inside 'LoggerConfig'.
 showTidB :: LoggerConfig
 showTidB = mempty { _lcShowTid = Any True }
-
--- | Setup 'lcFilePrefix' inside 'LoggerConfig' to optional prefix.
-maybeTimeFormatB :: Maybe Text -> LoggerConfig
-maybeTimeFormatB format = mempty { _lcTimeFormat = format }
 
 -- | Setup 'lcConsoleOutput' inside 'LoggerConfig'.
 consoleOutB :: LoggerConfig

--- a/src/System/Wlog/Wrapper.hs
+++ b/src/System/Wlog/Wrapper.hs
@@ -61,11 +61,17 @@ streamHandlerWithLock lock h sev = do
 -- 3. Applies `setSeverity` to given loggers. It can be done later using
 -- `setSeverity` directly.
 initTerminalLogging :: MonadIO m
-                    => Bool  -- ^ Show time?
+                    => Text
+                    -> Bool  -- ^ Show time?
                     -> Bool  -- ^ Show ThreadId?
                     -> Maybe Severity
                     -> m ()
-initTerminalLogging isShowTime isShowTid (fromMaybe Warning -> defaultSeverity) = liftIO $ do
+initTerminalLogging
+    timeFormat
+    isShowTime
+    isShowTid
+    (fromMaybe Warning -> defaultSeverity)
+  = liftIO $ do
     lock <- liftIO $ newMVar ()
     -- We set Debug here, to allow all messages by stdout handler.
     -- They will be filtered by loggers.
@@ -78,8 +84,8 @@ initTerminalLogging isShowTime isShowTid (fromMaybe Warning -> defaultSeverity) 
     updateGlobalLogger rootLoggerName $
         setLevel defaultSeverity
   where
-    setStdoutFormatter = (`setFormatter` stdoutFormatter isShowTime isShowTid)
-    setStderrFormatter = (`setFormatter` stderrFormatter isShowTid)
+    setStdoutFormatter = (`setFormatter` stdoutFormatter timeFormat isShowTime isShowTid)
+    setStderrFormatter = (`setFormatter` stderrFormatter timeFormat isShowTid)
 
 -- | Set severity for given logger. By default parent's severity is used.
 setSeverity :: MonadIO m => LoggerName -> Severity -> m ()

--- a/src/System/Wlog/Wrapper.hs
+++ b/src/System/Wlog/Wrapper.hs
@@ -24,6 +24,7 @@ module System.Wlog.Wrapper
 import           Universum
 
 import           Control.Concurrent.MVar    (withMVar)
+import           Data.Time                  (UTCTime)
 import           System.IO                  (Handle, stderr, stdout)
 
 import           System.Wlog.Formatter      (stderrFormatter, stdoutFormatter)
@@ -61,13 +62,13 @@ streamHandlerWithLock lock h sev = do
 -- 3. Applies `setSeverity` to given loggers. It can be done later using
 -- `setSeverity` directly.
 initTerminalLogging :: MonadIO m
-                    => Text
+                    => (UTCTime -> Text)
                     -> Bool  -- ^ Show time?
                     -> Bool  -- ^ Show ThreadId?
                     -> Maybe Severity
                     -> m ()
 initTerminalLogging
-    timeFormat
+    timeF
     isShowTime
     isShowTid
     (fromMaybe Warning -> defaultSeverity)
@@ -84,8 +85,8 @@ initTerminalLogging
     updateGlobalLogger rootLoggerName $
         setLevel defaultSeverity
   where
-    setStdoutFormatter = (`setFormatter` stdoutFormatter timeFormat isShowTime isShowTid)
-    setStderrFormatter = (`setFormatter` stderrFormatter timeFormat isShowTid)
+    setStdoutFormatter = (`setFormatter` stdoutFormatter timeF isShowTime isShowTid)
+    setStderrFormatter = (`setFormatter` stderrFormatter timeF isShowTid)
 
 -- | Set severity for given logger. By default parent's severity is used.
 setSeverity :: MonadIO m => LoggerName -> Severity -> m ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ packages:
 - '.'
 
 extra-deps:
+- fmt-0.5.0.0
 - universum-0.6.1
 
 nix:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.2
+resolver: lts-9.6
 packages:
 - '.'
 

--- a/test/Test/Wlog/RollingSpec.hs
+++ b/test/Test/Wlog/RollingSpec.hs
@@ -83,7 +83,7 @@ logThreadsNum = 4
 writeConcurrentLogs :: RotationParameters -> LinesToLog -> IO ()
 writeConcurrentLogs rp@RotationParameters{..} (getNumberOfLinesToLog -> linesNum) =
     bracket_
-        (setupLogging $ testLoggerConfig rp)
+        (setupLogging Nothing $ testLoggerConfig rp)
         releaseAllHandlers
         concurrentWriting
   where


### PR DESCRIPTION
Now by default milliseconds are shown every time. But you can customize logging format from config.