### PR TITLE
[CSL-1778] correct logger config parsing

### DIFF
--- a/src/System/Wlog/LoggerConfig.hs
+++ b/src/System/Wlog/LoggerConfig.hs
@@ -244,7 +244,13 @@ instance Monoid LoggerConfig where
 
 topLevelParams :: [Text]
 topLevelParams =
-    ["rotation", "showTime", "printOutput", "filePrefix" ]
+    [ "rotation"
+    , "termSeverity"
+    , "showTime"
+    , "showTid"
+    , "printOutput"
+    , "filePrefix"
+    ]
 
 instance FromJSON LoggerConfig where
     parseJSON = withObject "rotation params" $ \o -> do


### PR DESCRIPTION
Terminal logging severity couldn't be set due to a missing top level key.