### PR TITLE
[LW-25] Support custom actions with Handlers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+1.4.0
+=====
+
+* Add ability to specify custom logging action.
+
 1.3.4
 ====
 

--- a/examples/Playground.hs
+++ b/examples/Playground.hs
@@ -7,11 +7,11 @@ import           Universum
 import           Data.Monoid      ((<>))
 import           Data.Yaml.Pretty (defConfig, encodePretty)
 
-import           System.Wlog      (CanLog, buildAndSetupYamlLogging, dispatchEvents,
-                                   logDebug, logError, logInfo, logNotice, logWarning,
-                                   modifyLoggerName, parseLoggerConfig, prefixB,
-                                   productionB, releaseAllHandlers, runPureLog,
-                                   usingLoggerName)
+import           System.Wlog      (CanLog, Severity (Debug), buildAndSetupYamlLogging,
+                                   dispatchEvents, logDebug, logError, logInfo, logNotice,
+                                   logWarning, modifyLoggerName, parseLoggerConfig,
+                                   prefixB, productionB, releaseAllHandlers, runPureLog,
+                                   termSeverityB, usingLoggerName)
 
 testLoggerConfigPath :: FilePath
 testLoggerConfigPath = "logger-config-example.yaml"
@@ -46,7 +46,7 @@ showPureLog = do
 main :: IO ()
 main = do
     testToJsonConfigOutput
-    let config = (productionB <> prefixB "logs")
+    let config = (productionB <> prefixB "logs" <> termSeverityB Debug)
     bracket_
         (buildAndSetupYamlLogging config testLoggerConfigPath)
         releaseAllHandlers

--- a/log-warper.cabal
+++ b/log-warper.cabal
@@ -1,5 +1,5 @@
 name:                log-warper
-version:             1.3.4
+version:             1.4.0
 synopsis:            Flexible, configurable, monadic and pretty logging
 homepage:            https://github.com/serokell/log-warper
 license:             MIT

--- a/src/System/Wlog/Handler/Simple.hs
+++ b/src/System/Wlog/Handler/Simple.hs
@@ -17,10 +17,12 @@ Written by John Goerzen, jgoerzen\@complete.org
 -}
 
 module System.Wlog.Handler.Simple
-       ( streamHandler
+       ( GenericHandler(..)
+       , defaultHandleAction
+
+         -- * Custom handlers
        , fileHandler
-       , GenericHandler(..)
-       , verboseStreamHandler
+       , streamHandler
        ) where
 
 import           Control.Concurrent      (modifyMVar_, withMVar)
@@ -31,17 +33,14 @@ import           Data.Typeable           (Typeable)
 import           System.Directory        (createDirectoryIfMissing)
 import           System.FilePath         (takeDirectory)
 import           System.IO               (Handle, IOMode (ReadWriteMode),
-                                          SeekMode (SeekFromEnd), hClose,
-                                          hFlush, hSeek)
+                                          SeekMode (SeekFromEnd), hClose, hFlush, hSeek)
 import           Universum
 
-import           System.Wlog.Formatter   (LogFormatter, nullFormatter,
-                                          simpleLogFormatter)
+import           System.Wlog.Formatter   (LogFormatter, nullFormatter)
 import           System.Wlog.Handler     (LogHandler (..), LogHandlerTag (..))
 import           System.Wlog.MemoryQueue (MemoryQueue)
 import           System.Wlog.MemoryQueue as MQ
 import           System.Wlog.Severity    (Severity (..))
-
 
 -- | A helper data type.
 data GenericHandler a = GenericHandler
@@ -64,39 +63,57 @@ instance Typeable a => LogHandler (GenericHandler a) where
     emit sh bldr _ = (writeFunc sh) (privData sh) (toText . B.toLazyText $ bldr)
     close sh = (closeFunc sh) (privData sh)
 
+-- | Default action which just prints to handle using given message.
+defaultHandleAction :: Handle -> Text -> IO ()
+defaultHandleAction h message =
+    TIO.hPutStrLn h message `catch` handleWriteException
+  where
+    handleWriteException :: SomeException -> IO ()
+    handleWriteException e = do
+        let errorMessage = "Error writing log message: "
+                        <> show e <> " (original message: " <> message <> ")"
+        TIO.hPutStrLn h errorMessage
+
+-- | Creates custom write action and memory queue where write action
+-- updates memory queue as well.
+createWriteFuncWrapper
+    :: (Handle -> Text -> IO ())
+    -> MVar ()
+    -> IO ( Handle -> Text -> IO ()
+          , MVar (MemoryQueue Text)
+          )
+createWriteFuncWrapper action lock = do
+    memoryQueue <- newMVar $ MQ.newMemoryQueue $ 2 * 1024 * 1024 -- 2 MB
+
+    let customWriteFunc :: Handle -> Text -> IO ()
+        customWriteFunc hdl msg = withMVar lock $ const $ do
+            action hdl msg
+
+            -- Important to force the queue here, else a massive closure will
+            -- be retained until the queue is actually used.
+            modifyMVar_ memoryQueue $ \mq -> pure $! pushFront msg mq
+
+            hFlush hdl
+
+    return (customWriteFunc, memoryQueue)
+
 -- | Create a stream log handler. Log messages sent to this handler
 -- will be sent to the stream used initially. Note that the 'close'
 -- method will have no effect on stream handlers; it does not actually
 -- close the underlying stream.
-streamHandler :: Handle -> Severity -> IO (GenericHandler Handle)
-streamHandler h sev = do
-    lock <- newMVar ()
-    mq <- newMVar $ MQ.newMemoryQueue $ 2 * 1024 * 1024 -- 2 MB
-    let mywritefunc hdl msg = withMVar lock $ const $ do
-            writeToHandle hdl msg
-            -- Important to force the queue here, else a massive closure will
-            -- be retained until the queue is actually used.
-            modifyMVar_ mq $ \mq' -> pure $! pushFront msg mq'
-            hFlush hdl
-    return
-        GenericHandler
-        { severity = sev
-        , formatter = nullFormatter
-        , privData = h
-        , writeFunc = mywritefunc
+streamHandler :: Handle
+              -> (Handle -> Text -> IO ())
+              -> MVar ()
+              -> Severity
+              -> IO (GenericHandler Handle)
+streamHandler privData writeAction lock severity = do
+    (writeFunc, readBackBuffer) <- createWriteFuncWrapper writeAction lock
+    return GenericHandler
+        { formatter = nullFormatter
         , closeFunc = const $ pure ()
-        , readBackBuffer = mq
-        , ghTag = HandlerOther "GenericHandler/StreamHandler"
+        , ghTag     = HandlerOther "GenericHandler/StreamHandler"
+        , ..
         }
-  where
-    writeToHandle hdl msg =
-        TIO.hPutStrLn hdl msg `catch` (handleWriteException hdl msg)
-    handleWriteException :: Handle -> Text -> SomeException -> IO ()
-    handleWriteException hdl msg e =
-        let msg' =
-                "Error writing log message: " <>
-                show e <> " (original message: " <> msg <> ")"
-        in TIO.hPutStrLn hdl msg'
 
 -- | Create a file log handler.  Log messages sent to this handler
 -- will be sent to the filename specified, which will be opened in
@@ -106,15 +123,9 @@ fileHandler fp sev = do
     createDirectoryIfMissing True (takeDirectory fp)
     h <- openFile fp ReadWriteMode
     hSeek h SeekFromEnd 0
-    sh <- streamHandler h sev
+
+    lock <- newMVar ()
+    sh <- streamHandler h defaultHandleAction lock sev
     pure $ sh { closeFunc = hClose
               , ghTag = HandlerFilelike fp
               }
-
--- | Like 'streamHandler', but note the priority and logger name along
--- with each message.
-verboseStreamHandler :: Handle -> Severity -> IO (GenericHandler Handle)
-verboseStreamHandler h sev =
-    let fmt = simpleLogFormatter "[$loggername/$prio] $msg"
-    in do hndlr <- streamHandler h sev
-          return $ setFormatter hndlr fmt


### PR DESCRIPTION
This PR introduces ability to specify custom printing actions to terminal. Unfortunately, is wasn't so trivial. The action should be specified in form `Handle -> Text -> IO ()`. Also this PR refactors some logic in handlers. One redundant `MVar` for each terminal handler was removed. I hope it works (tested locally, seems to work).