### PR TITLE
Round picoseconds by power of ten

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
   Add `Exception` module with `logException` and `catchLog` functions.
 * [#60](https://github.com/serokell/log-warper/issues/60):
   Fix documentation for `termSeveritiesOut` and `termSeveritiesErr`.
+* [#63](https://github.com/serokell/log-warper/issues/63):
+  Timestamp rounding by powers of 10.
 
 1.7.1
 =====

--- a/src/System/Wlog/LoggerConfig.hs
+++ b/src/System/Wlog/LoggerConfig.hs
@@ -114,7 +114,9 @@ data HandlerWrap = HandlerWrap
     { _hwFilePath :: !FilePath
       -- ^ Path to the file to be handled.
     , _hwRounding :: !(Maybe Int)
-      -- ^ Amount of seconds to round time on (if set).
+      -- ^ Round timestamps to this power of 10 picoseconds.
+      -- Just 3 would round to nanoseconds.
+      -- Just 12 would round to seconds.
     } deriving (Generic,Show)
 
 makeLenses ''HandlerWrap


### PR DESCRIPTION
Previously you could round the seconds by arbitrary divisor.
Perhaps my imagination fails me but I don't think this is a useful
feature. I've come across logs in which all timestamps are rounded to 5
seconds, severly reducing their usefulness.

This patch changes the meaning of the `Int` parameter to the rounded
logging formatter. It now gives the number of least-significant digits
of the picosecond timestamps that should be forgotten, i.e. your
timestamp will be  s * 10^n  picoseconds.