### PR TITLE
Bump ansi-terminal upper bound to <0.9

### DIFF
--- a/log-warper.cabal
+++ b/log-warper.cabal
@@ -47,7 +47,7 @@ library
 
   build-depends:       base                 >= 4.9 && < 5
                      , aeson                ^>= 1.2
-                     , ansi-terminal        ^>= 0.7
+                     , ansi-terminal        >= 0.7 && < 0.9
                      , containers           ^>= 0.5.7.1
                      , deepseq              ^>= 1.4
                      , directory            ^>= 1.3


### PR DESCRIPTION
Bump `ansi-terminal` upper bound to <0.9, in response to https://github.com/fpco/stackage/issues/3143.