### PR TITLE
do not catch and squelch async exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.8.10
+======
+
+* Remove exception handler from simple logger, which would catch all exceptions,
+  even asynchronous ones.
+
 1.8.9
 =====
 

--- a/log-warper.cabal
+++ b/log-warper.cabal
@@ -1,5 +1,5 @@
 name:                log-warper
-version:             1.8.9
+version:             1.8.10
 synopsis:            Flexible, configurable, monadic and pretty logging
 homepage:            https://github.com/serokell/log-warper
 license:             MIT

--- a/src/System/Wlog/LogHandler/Simple.hs
+++ b/src/System/Wlog/LogHandler/Simple.hs
@@ -27,7 +27,6 @@ module System.Wlog.LogHandler.Simple
 import Universum
 
 import Control.Concurrent (modifyMVar_, withMVar)
-import Control.Exception (IOException)
 import Data.Text.Lazy.Builder as B
 import Data.Typeable (Typeable)
 import System.Directory (createDirectoryIfMissing)
@@ -64,18 +63,7 @@ instance Typeable a => LogHandler (GenericHandler a) where
 
 -- | Default action which just prints to handle using given message.
 defaultHandleAction :: Handle -> Text -> IO ()
-defaultHandleAction h message =
-    -- Catch IOExceptions, which are always synchronous.
-    -- It's very important that we don't catch SomeException, as was previously
-    -- the case, because it can and did squelch an exception that should have
-    -- killed this thread.
-    TIO.hPutStrLn h message `catch` handleWriteException
-  where
-    handleWriteException :: IOException -> IO ()
-    handleWriteException e = do
-        let errorMessage = "Error writing log message: "
-                        <> show e <> " (original message: " <> message <> ")"
-        TIO.hPutStrLn h errorMessage
+defaultHandleAction = TIO.hPutStrLn
 
 -- | Creates custom write action and memory queue where write action
 -- updates memory queue as well.

--- a/src/System/Wlog/LogHandler/Simple.hs
+++ b/src/System/Wlog/LogHandler/Simple.hs
@@ -27,6 +27,7 @@ module System.Wlog.LogHandler.Simple
 import Universum
 
 import Control.Concurrent (modifyMVar_, withMVar)
+import Control.Exception (IOException)
 import Data.Text.Lazy.Builder as B
 import Data.Typeable (Typeable)
 import System.Directory (createDirectoryIfMissing)
@@ -64,9 +65,13 @@ instance Typeable a => LogHandler (GenericHandler a) where
 -- | Default action which just prints to handle using given message.
 defaultHandleAction :: Handle -> Text -> IO ()
 defaultHandleAction h message =
+    -- Catch IOExceptions, which are always synchronous.
+    -- It's very important that we don't catch SomeException, as was previously
+    -- the case, because it can and did squelch an exception that should have
+    -- killed this thread.
     TIO.hPutStrLn h message `catch` handleWriteException
   where
-    handleWriteException :: SomeException -> IO ()
+    handleWriteException :: IOException -> IO ()
     handleWriteException e = do
         let errorMessage = "Error writing log message: "
                         <> show e <> " (original message: " <> message <> ")"


### PR DESCRIPTION
This caused the following bug: a child thread, spawned by withAsync, and
linked to the main thread, threw an exception. The main thread was
presently trying to log something, so this simple logger grabbed the
async exception and tossed it out.

Solution: catch only IOExceptions.

This should also raise the question: if there's an exception in logging,
should we log it? i.e. should we have this exception handler at all? TBD